### PR TITLE
Disable a2dp-sink, because it is not supported and breaks bt-audio.

### DIFF
--- a/overlay/packages/apps/Bluetooth/res/values/config.xml
+++ b/overlay/packages/apps/Bluetooth/res/values/config.xml
@@ -32,5 +32,4 @@
 <resources>
     <bool name="profile_supported_hfpclient">true</bool>
     <bool name="profile_supported_avrcp_controller">true</bool>
-    <bool name="profile_supported_a2dp_sink">true</bool>
 </resources>


### PR DESCRIPTION
Should fix bluetooth-audio.
Fetched from https://github.com/LineageOS/android_device_xiaomi_msm8998-common/commit/cc15b2b46d222f5976c88165946967f17a5e1ce3